### PR TITLE
remove default foreground option from pidfile context

### DIFF
--- a/xivo_stat/bin/stat.py
+++ b/xivo_stat/bin/stat.py
@@ -36,7 +36,7 @@ def main():
     setup_logging(LOGFILENAME, debug=False, log_format=log_format)
 
     command = _XivoStatCommand()
-    with pidfile_context(PIDFILENAME, foreground=True):
+    with pidfile_context(PIDFILENAME):
         argparse_cmd.execute_command(command)
 
 


### PR DESCRIPTION
reason: default is now to True and will be removed since no one use it